### PR TITLE
fixes relative to compilation

### DIFF
--- a/mirror_base.h
+++ b/mirror_base.h
@@ -4,7 +4,7 @@
 #include <unordered_map>
 #include <vector>
 #include <set>
-#include <string.h>
+#include <string>
 #include <type_traits>
 #include <typeinfo>
 

--- a/mirror_base.h
+++ b/mirror_base.h
@@ -143,6 +143,20 @@ namespace mirror
 		}
 	};
 
+	template <> struct TypeDescGetter<void> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_void); return &s_typeDesc; } };
+	template <> struct TypeDescGetter<bool> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_bool); return &s_typeDesc; } };
+	template <> struct TypeDescGetter<char> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_char); return &s_typeDesc; } };
+	template <> struct TypeDescGetter<int8_t> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_int8); return &s_typeDesc; } };
+	template <> struct TypeDescGetter<int16_t> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_int16); return &s_typeDesc; } };
+	template <> struct TypeDescGetter<int32_t> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_int32); return &s_typeDesc; } };
+	template <> struct TypeDescGetter<int64_t> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_int64); return &s_typeDesc; } };
+	template <> struct TypeDescGetter<uint8_t> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_uint8); return &s_typeDesc; } };
+	template <> struct TypeDescGetter<uint16_t> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_uint16); return &s_typeDesc; } };
+	template <> struct TypeDescGetter<uint32_t> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_uint32); return &s_typeDesc; } };
+	template <> struct TypeDescGetter<uint64_t> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_uint64); return &s_typeDesc; } };
+	template <> struct TypeDescGetter<float> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_float); return &s_typeDesc; } };
+	template <> struct TypeDescGetter<double> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_double); return &s_typeDesc; } };
+
 	template <typename T>
 	struct TypeDescGetter<T, void, std::enable_if_t<std::is_enum<T>::value>>
 	{
@@ -158,21 +172,7 @@ namespace mirror
 			return nullptr;
 		}
 	};
-
-	template <> struct TypeDescGetter<void> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_void); return &s_typeDesc; } };
-	template <> struct TypeDescGetter<bool> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_bool); return &s_typeDesc; } };
-	template <> struct TypeDescGetter<char> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_char); return &s_typeDesc; } };
-	template <> struct TypeDescGetter<int8_t> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_int8); return &s_typeDesc; } };
-	template <> struct TypeDescGetter<int16_t> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_int16); return &s_typeDesc; } };
-	template <> struct TypeDescGetter<int32_t> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_int32); return &s_typeDesc; } };
-	template <> struct TypeDescGetter<int64_t> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_int64); return &s_typeDesc; } };
-	template <> struct TypeDescGetter<uint8_t> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_uint8); return &s_typeDesc; } };
-	template <> struct TypeDescGetter<uint16_t> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_uint16); return &s_typeDesc; } };
-	template <> struct TypeDescGetter<uint32_t> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_uint32); return &s_typeDesc; } };
-	template <> struct TypeDescGetter<uint64_t> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_uint64); return &s_typeDesc; } };
-	template <> struct TypeDescGetter<float> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_float); return &s_typeDesc; } };
-	template <> struct TypeDescGetter<double> { static TypeDesc* Get() { static TypeDesc s_typeDesc = TypeDesc(Type_double); return &s_typeDesc; } };
-
+	
 	template <typename T>
 	TypeDesc* GetTypeDesc(T) { return TypeDescGetter<T>::Get(); }
 

--- a/mirror_base.h
+++ b/mirror_base.h
@@ -139,7 +139,8 @@ namespace mirror
 	{
 		static TypeDesc* Get()
 		{
-			static PointerTypeDesc s_pointerTypeDesc(TypeDescGetter<std::remove_pointer<T>::type>::Get()); return &s_pointerTypeDesc;
+			using type = typename std::remove_pointer<T>::type;
+			static PointerTypeDesc s_pointerTypeDesc(TypeDescGetter<type>::Get()); return &s_pointerTypeDesc;
 		}
 	};
 
@@ -172,7 +173,7 @@ namespace mirror
 			return nullptr;
 		}
 	};
-	
+
 	template <typename T>
 	TypeDesc* GetTypeDesc(T) { return TypeDescGetter<T>::Get(); }
 
@@ -190,29 +191,17 @@ namespace mirror
 	template <typename DestType, typename SourceType, typename IsDestLastPointer = void, typename IsSourceLastPointer = void>
 	struct CastClassesUnpiler
 	{
+		static_assert(!std::is_pointer<DestType>::value, "Mismatching pointer count between cast source and cast destination (DestType is not a pointer).");
+		static_assert(!std::is_pointer<SourceType>::value, "Mismatching pointer count between cast source and cast destination (SourceType is not a pointer).");
+
 		static bool Unpile(Class** _destClass, Class** _sourceClass)
 		{
-			return CastClassesUnpiler<std::remove_pointer<DestType>::type, std::remove_pointer<SourceType>::type>::Unpile(_destClass, _sourceClass);
+			using source_t = typename std::remove_pointer<SourceType>::type;
+			using dest_t   = typename std::remove_pointer<DestType>::type;
+			return CastClassesUnpiler<dest_t, source_t>::Unpile(_destClass, _sourceClass);
 		}
 	};
 
-	template <typename DestType, typename SourceType>
-	struct CastClassesUnpiler<DestType, SourceType, std::enable_if_t<std::is_pointer<DestType>::value>, std::enable_if_t<!std::is_pointer<SourceType>::value>>
-	{
-		static bool Unpile(Class** _destClass, Class** _sourceClass)
-		{
-			static_assert(false, "Mismatching pointer count between cast source and cast destination.");
-		}
-	};
-
-	template <typename DestType, typename SourceType>
-	struct CastClassesUnpiler<DestType, SourceType, std::enable_if_t<!std::is_pointer<DestType>::value>, std::enable_if_t<std::is_pointer<SourceType>::value>>
-	{
-		static bool Unpile(Class** _destClass, Class** _sourceClass)
-		{
-			static_assert(false, "Mismatching pointer count between cast source and cast destination.");
-		}
-	};
 
 	template <typename DestType, typename SourceType>
 	struct CastClassesUnpiler<DestType, SourceType, std::enable_if_t<!std::is_pointer<DestType>::value>, std::enable_if_t<!std::is_pointer<SourceType>::value>>

--- a/tools/BinarySerializer.cpp
+++ b/tools/BinarySerializer.cpp
@@ -1,7 +1,7 @@
 #include "BinarySerializer.h"
 
 #include <cassert>
-
+#include <cstring>
 #include "../mirror.h"
 
 namespace mirror


### PR DESCRIPTION
This merge request contain three corrections:

- template declaration order changed in order to compile.
- add of `template` keywords + a refactor for `CastClassesUnpiler` in order to avoid `static_assert( bool, ....)` (the compiler is allowed to emit an error for them event if they are not instantiated, I changed them for a template dependent [bool_constexpr](https://en.cppreference.com/w/cpp/language/static_assert) )
- `#include <string.h>` replaced by `#include <string>`